### PR TITLE
Check MySQL readiness (in case it is not fully ready after 20 seconds)

### DIFF
--- a/docker-entry.sh
+++ b/docker-entry.sh
@@ -2,17 +2,14 @@
 # Copyright (c) 2016 Mattermost, Inc. All Rights Reserved.
 # See License.txt for license information.
 
-echo starting mysql
+echo "Starting MySQL"
 /entrypoint.sh mysqld &
 
-sleep 20
-
 until mysqladmin -hlocalhost -P3306 -u"$MYSQL_USER" -p"$MYSQL_PASSWORD" processlist &> /dev/null; do
-    echo "MySQL still not ready, sleeping"
-    sleep 5
+	echo "MySQL still not ready, sleeping"
+	sleep 5
 done
 
-echo starting platform
+echo "Starting platform"
 cd mattermost
-./bin/platform -config=config/config_docker.json
-sleep 1000000
+exec ./bin/platform -config=config/config_docker.json

--- a/docker-entry.sh
+++ b/docker-entry.sh
@@ -7,6 +7,11 @@ echo starting mysql
 
 sleep 20
 
+until mysqladmin -hlocalhost -P3306 -u"$MYSQL_USER" -p"$MYSQL_PASSWORD" processlist &> /dev/null; do
+    echo "MySQL still not ready, sleeping"
+    sleep 5
+done
+
 echo starting platform
 cd mattermost
 ./bin/platform -config=config/config_docker.json


### PR DESCRIPTION
This modifies the entrypoint script to check MySQL for readiness before starting Mattermost. I have also tested removing the 20 second sleep altogether and that seems to work fine with this method. Let me know if that is desired and I can modify the commit to also do that.