### PR TITLE
Update config_docker.json for Mattermost 3.2

### DIFF
--- a/config_docker.json
+++ b/config_docker.json
@@ -1,5 +1,6 @@
 {
     "ServiceSettings": {
+        "SiteURL": "",
         "ListenAddress": ":8065",
         "MaximumLoginAttempts": 10,
         "SegmentDeveloperKey": "",
@@ -23,7 +24,9 @@
         "SessionCacheInMinutes": 10,
         "WebsocketSecurePort": 443,
         "WebsocketPort": 80,
-        "WebserverMode": "regular"
+        "WebserverMode": "gzip",
+        "EnableCustomEmoji": true,
+        "RestrictCustomEmojiCreation": "all"
     },
     "TeamSettings": {
         "SiteName": "Mattermost",
@@ -35,7 +38,12 @@
         "RestrictTeamNames": true,
         "EnableCustomBrand": false,
         "CustomBrandText": "",
-        "RestrictDirectMessage": "any"
+        "CustomDescriptionText": "",
+        "RestrictDirectMessage": "any",
+        "RestrictTeamInvite": "all",
+        "RestrictPublicChannelManagement": "all",
+        "RestrictPrivateChannelManagement": "all",
+        "UserStatusAwayTimeout": 300
     },
     "SqlSettings": {
         "DriverName": "mysql",
@@ -52,7 +60,15 @@
         "EnableFile": true,
         "FileLevel": "INFO",
         "FileFormat": "",
-        "FileLocation": ""
+        "FileLocation": "",
+        "EnableWebhookDebugging": false
+    },
+    "PasswordSettings": {
+        "MinimumLength": 5,
+        "Lowercase": false,
+        "Number": false,
+        "Uppercase": false,
+        "Symbol": false
     },
     "FileSettings": {
         "MaxFileSize": 52428800,
@@ -84,6 +100,7 @@
         "RequireEmailVerification": false,
         "FeedbackName": "",
         "FeedbackEmail": "",
+        "FeedbackOrganization": "",
         "SMTPUsername": "",
         "SMTPPassword": "",
         "SMTPServer": "",
@@ -111,7 +128,7 @@
         "PrivacyPolicyLink": "https://about.mattermost.com/default-privacy-policy/",
         "AboutLink": "https://about.mattermost.com/default-about/",
         "HelpLink": "https://about.mattermost.com/default-help/",
-        "ReportAProblemLink": "https://about.mattermost.com/default-report-problem/",
+        "ReportAProblemLink": "https://about.mattermost.com/default-report-a-problem/",
         "SupportEmail": "feedback@mattermost.com"
     },
     "GitLabSettings": {
@@ -127,10 +144,19 @@
         "Enable": false,
         "Secret": "",
         "Id": "",
-        "Scope": "",
-        "AuthEndpoint": "",
-        "TokenEndpoint": "",
-        "UserApiEndpoint": ""
+        "Scope": "profile email",
+        "AuthEndpoint": "https://accounts.google.com/o/oauth2/v2/auth",
+        "TokenEndpoint": "https://www.googleapis.com/oauth2/v4/token",
+        "UserApiEndpoint": "https://www.googleapis.com/plus/v1/people/me"
+    },
+    "Office365Settings": {
+        "Enable": false,
+        "Secret": "",
+        "Id": "",
+        "Scope": "User.Read",
+        "AuthEndpoint": "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
+        "TokenEndpoint": "https://login.microsoftonline.com/common/oauth2/v2.0/token",
+        "UserApiEndpoint": "https://graph.microsoft.com/v1.0/me"
     },
     "LdapSettings": {
         "Enable": false,
@@ -147,13 +173,48 @@
         "UsernameAttribute": "",
         "NicknameAttribute": "",
         "IdAttribute": "",
+        "SyncIntervalMinutes": 60,
         "SkipCertificateVerification": false,
         "QueryTimeout": 60,
+        "MaxPageSize": 0,
         "LoginFieldName": ""
     },
     "ComplianceSettings": {
         "Enable": false,
         "Directory": "./data/",
         "EnableDaily": false
+    },
+    "LocalizationSettings": {
+        "DefaultServerLocale": "en",
+        "DefaultClientLocale": "en",
+        "AvailableLocales": ""
+    },
+    "SamlSettings": {
+        "Enable": false,
+        "Verify": false,
+        "Encrypt": false,
+        "IdpUrl": "",
+        "IdpDescriptorUrl": "",
+        "AssertionConsumerServiceURL": "",
+        "IdpCertificateFile": "",
+        "PublicCertificateFile": "",
+        "PrivateKeyFile": "",
+        "FirstNameAttribute": "",
+        "LastNameAttribute": "",
+        "EmailAttribute": "",
+        "UsernameAttribute": "",
+        "NicknameAttribute": "",
+        "LocaleAttribute": "",
+        "LoginButtonText": "With SAML"
+    },
+    "NativeAppSettings": {
+        "AppDownloadLink": "https://about.mattermost.com/downloads/",
+        "AndroidAppDownloadLink": "https://about.mattermost.com/mattermost-android-app/",
+        "IosAppDownloadLink": "https://about.mattermost.com/mattermost-ios-app/"
+    },
+    "ClusterSettings": {
+        "Enable": false,
+        "InterNodeListenAddress": ":8075",
+        "InterNodeUrls": []
     }
 }


### PR DESCRIPTION
The config_docker.json did not include Mattermost 3.2 new configuration items. This patch adds Mattermost new configuration items.
