### PR TITLE
Add updating CA certificates

### DIFF
--- a/docker-entry.sh
+++ b/docker-entry.sh
@@ -10,6 +10,9 @@ until mysqladmin -hlocalhost -P3306 -u"$MYSQL_USER" -p"$MYSQL_PASSWORD" processl
 	sleep 5
 done
 
+echo "Updating CA certificates"
+update-ca-certificates --fresh >/dev/null
+
 echo "Starting platform"
 cd mattermost
 exec ./bin/platform --config=config/config_docker.json


### PR DESCRIPTION
Proposal for https/SSL communication to use additional certificate such as internal root certificate, self-signed certificate.