### PR TITLE
Upgrade to mattermost 5.0.0

### DIFF
--- a/docker-entry.sh
+++ b/docker-entry.sh
@@ -12,4 +12,4 @@ done
 
 echo "Starting platform"
 cd mattermost
-exec ./bin/platform --config=config/config_docker.json
+exec ./bin/mattermost --config=config/config_docker.json


### PR DESCRIPTION
Upgrade to mattermost 5.0.0 indicated an error.
```
mattermost_1 | ------------------------------------ ERROR ------------------------------------------------
mattermost_1 | The platform binary has been deprecated, please switch to using the new mattermost binary.
mattermost_1 | The platform binary will be removed in a future version.
mattermost_1 | -------------------------------------------------------------------------------------------
```
#32 Fix.