### PR TITLE
docker: added environment variables for Mattermost preview

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ENV MYSQL_DATABASE=mattermost_test
 # Configure Mattermost ENV
 
 ENV PATH /mm/mattermost/bin/mattermost:$PATH
-ENV PATH /mm/mattermost/bin/platform:$PATH
+ENV PATH /mm/mattermost/bin/platform:$PAT
 
 #
 # Configure Mattermost

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ENV MYSQL_DATABASE=mattermost_test
 # Configure Mattermost ENV
 
 ENV PATH /mm/mattermost/bin/mattermost:$PATH
-ENV PATH /mm/mattermost/bin/platform:$PAT
+ENV PATH /mm/mattermost/bin/platform:$PATH
 
 #
 # Configure Mattermost

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,7 @@ ENV MYSQL_DATABASE=mattermost_test
 
 # Configure Mattermost ENV
 
-ENV PATH /mm/mattermost/bin/mattermost:$PATH
-ENV PATH /mm/mattermost/bin/platform:$PATH
+ENV PATH /mm/mattermost/bin:$PATH
 
 #
 # Configure Mattermost

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,11 @@ ENV MYSQL_USER=mmuser
 ENV MYSQL_PASSWORD=mostest
 ENV MYSQL_DATABASE=mattermost_test
 
+# Configure Mattermost ENV
+
+ENV mattermost=/mm/mattermost/bin/mattermost
+ENV platform=/mm/mattermost/bin/platform
+
 #
 # Configure Mattermost
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,7 @@ ENV MYSQL_DATABASE=mattermost_test
 
 # Configure Mattermost ENV
 
-ENV mattermost=/mm/mattermost/bin/mattermost
-ENV platform=/mm/mattermost/bin/platform
+ENV PATH "$PATH:/mm/mattermost/bin/mattermost:/mm/mattermost/bin/platform"
 
 #
 # Configure Mattermost

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ ENV MYSQL_DATABASE=mattermost_test
 #
 # Configure Mattermost
 #
+
 WORKDIR /mm
 
 # Copy over files
@@ -31,6 +32,9 @@ ENTRYPOINT ./docker-entry.sh
 # Create default storage directory
 RUN mkdir ./mattermost-data
 VOLUME ./mattermost-data
+
+# Add Mattermost environment variables
+CMD export PATH=/mm/mattermost/bin
 
 # Ports
 EXPOSE 8065

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,6 @@ ENV MYSQL_USER=mmuser
 ENV MYSQL_PASSWORD=mostest
 ENV MYSQL_DATABASE=mattermost_test
 
-# Configure Mattermost ENV
-
-ENV PATH /mm/mattermost/bin:$PATH
-
 #
 # Configure Mattermost
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,8 @@ ENV MYSQL_DATABASE=mattermost_test
 
 # Configure Mattermost ENV
 
-ENV PATH "$PATH:/mm/mattermost/bin/mattermost:/mm/mattermost/bin/platform"
+ENV PATH /mm/mattermost/bin/mattermost:$PATH
+ENV PATH /mm/mattermost/bin/platform:$PATH
 
 #
 # Configure Mattermost

--- a/docker-entry.sh
+++ b/docker-entry.sh
@@ -2,6 +2,9 @@
 # Copyright (c) 2016 Mattermost, Inc. All Rights Reserved.
 # See License.txt for license information.
 
+# Add Mattermost environment variables
+export PATH=/mm/mattermost/bin
+
 echo "Starting MySQL"
 /entrypoint.sh mysqld &
 
@@ -13,6 +16,3 @@ done
 echo "Starting platform"
 cd mattermost
 exec ./bin/platform --config=config/config_docker.json
-
-# Add Mattermost environment variables
-export PATH=/mm/mattermost/bin

--- a/docker-entry.sh
+++ b/docker-entry.sh
@@ -2,9 +2,6 @@
 # Copyright (c) 2016 Mattermost, Inc. All Rights Reserved.
 # See License.txt for license information.
 
-# Add Mattermost environment variables
-export PATH=${PATH}:/mm/mattermost/bin
-
 echo "Starting MySQL"
 /entrypoint.sh mysqld &
 
@@ -16,3 +13,6 @@ done
 echo "Starting platform"
 cd mattermost
 exec ./bin/platform --config=config/config_docker.json
+
+# Add Mattermost environment variables
+export PATH=/mm/mattermost/bin

--- a/docker-entry.sh
+++ b/docker-entry.sh
@@ -4,7 +4,6 @@
 
 # Add Mattermost environment variables
 export PATH=${PATH}:/mm/mattermost/bin
-set -e
 
 echo "Starting MySQL"
 /entrypoint.sh mysqld &

--- a/docker-entry.sh
+++ b/docker-entry.sh
@@ -4,6 +4,7 @@
 
 # Add Mattermost environment variables
 export PATH=${PATH}:/mm/mattermost/bin
+set -e
 
 echo "Starting MySQL"
 /entrypoint.sh mysqld &

--- a/docker-entry.sh
+++ b/docker-entry.sh
@@ -2,9 +2,6 @@
 # Copyright (c) 2016 Mattermost, Inc. All Rights Reserved.
 # See License.txt for license information.
 
-# Add Mattermost environment variables
-export PATH=/mm/mattermost/bin
-
 echo "Starting MySQL"
 /entrypoint.sh mysqld &
 

--- a/docker-entry.sh
+++ b/docker-entry.sh
@@ -2,6 +2,9 @@
 # Copyright (c) 2016 Mattermost, Inc. All Rights Reserved.
 # See License.txt for license information.
 
+# Add Mattermost environment variables
+export PATH=${PATH}:/mm/mattermost/bin
+
 echo "Starting MySQL"
 /entrypoint.sh mysqld &
 


### PR DESCRIPTION
**Summary:**

When I used the Mattermost preview image, I noticed that the image doesn't have /mm/mattermost/bin in the PATH variable. I feel adding the bin directory to the PATH variable will make using the CLI easier for users. This fix will allow users to run Mattermost CLI commands without having to specify the mattermost/bin directory.

If I'm missing anything, please let me know and I'll fix.

Signed-off-by: James McClune <jmcclune@mcclunetechnologies.net>