### PR TITLE
docker: added ENV variables for Mattermost preview

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,9 @@ ADD docker-entry.sh .
 RUN chmod +x ./docker-entry.sh
 ENTRYPOINT ./docker-entry.sh
 
+# Mattermost environment variables
+ENV PATH="/mm/mattermost/bin:${PATH}"
+
 # Create default storage directory
 RUN mkdir ./mattermost-data
 VOLUME ./mattermost-data


### PR DESCRIPTION
**Summary:**

When I used the Mattermost preview image, I noticed that the image doesn't have /mm/mattermost/bin in the PATH variable. I feel adding the bin directory to the PATH variable will make using the CLI easier for users. This fix will allow users to run Mattermost CLI commands without having to specify the mattermost/bin directory.

If I'm missing anything, please let me know and I'll fix.

Signed-off-by: James McClune <jmcclune@mcclunetechnologies.net>