### PR TITLE
readme: add dockerhost to preview command

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,5 +15,5 @@ Please see [documentation for usage](http://docs.mattermost.com/install/docker-l
 If you have Docker already set up, you can run this image in one line:
 
 ```
-docker run --name mattermost-preview -d --publish 8065:8065 mattermost/mattermost-preview
+docker run --name mattermost-preview -d --publish 8065:8065 --add-host dockerhost:127.0.0.1 mattermost/mattermost-preview
 ```


### PR DESCRIPTION
Added --add-host dockerhost:127.0.0.1 to Docker preview image command.
This will avoid possible DB ping issues.

Similar to https://github.com/mattermost/docs/pull/2144

Signed-off-by: James McClune <jmcclune@mcclunetechnologies.net>