### PR TITLE
Dockerfile: changed WORKDIR to /mm/mattermost

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ENV MYSQL_DATABASE=mattermost_test
 #
 # Configure Mattermost
 #
-WORKDIR /mm
+WORKDIR /mm/mattermost
 
 # Copy over files
 ADD https://releases.mattermost.com/5.4.0-rc2/mattermost-team-5.4.0-rc2-linux-amd64.tar.gz .


### PR DESCRIPTION
I feel it's more convenient to set the WORKDIR to /mm/mattermost. 
This will prevent issues like ```"Failed to start up plugins",
"error":"mkdir ./client/plugins: no such file or directory"```

This was discussed in https://github.com/mattermost/docs/pull/2310.

Signed-off-by: James McClune <jmcclune@mcclunetechnologies.net>