### PR TITLE
FIX: Change VOLUME definition to be complient with gVisor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ ENV PATH="/mm/mattermost/bin:${PATH}"
 
 # Create default storage directory
 RUN mkdir ./mattermost-data
-VOLUME ./mattermost-data
+VOLUME /mm/mattermost-data
 
 # Ports
 EXPOSE 8065


### PR DESCRIPTION
Hi again!

Applying this pull request, the container image will be compliant with the gVisor runtime. 

`VOLUME` attribute has to have an absolute path value instead of a relative one.

This PR will fix #45 @cpanato 

I tried to deploy this *(modified)* container image and now it starts in a kubernetes with gVisor as pod sanbox.

```bash
$ kubectl get pods
NAME                          READY   STATUS    RESTARTS   AGE
mattermost-66b76f9795-qrvtg   1/1     Running   0          9m29s
```

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: mattermost
spec:
  selector:
    matchLabels:
      app: mattermost
  replicas: 1
  template:
    metadata:
      labels:
        app: mattermost
    spec:
      containers:
      - name: mattermost
        image: angelbarrera92/mattermost:dev
        ports:
        - containerPort: 8065
```

Thanks!