### PR TITLE
Fix ExperimentalDefaultChannels

### DIFF
--- a/config_docker.json
+++ b/config_docker.json
@@ -106,7 +106,7 @@
         "ExperimentalHideTownSquareinLHS": false,
         "ExperimentalTownSquareIsReadOnly": false,
         "ExperimentalPrimaryTeam": "",
-        "ExperimentalDefaultChannels": ""
+        "ExperimentalDefaultChannels": []
     },
     "DisplaySettings": {
         "CustomUrlSchemes": [],


### PR DESCRIPTION
Mattermost 5.27.0 changed `TeamSettings.ExperimentalDefaultChannels` to an array, and Mattermost will fail to start with this error if it's set to a string:

```
Error: failed to load configuration: failed to create store: unable to load on store creation: parsing error at line 109, character 42: json: cannot unmarshal string into Go struct field TeamSettings.TeamSettings.ExperimentalDefaultChannels of type []string
```

Resolves Issue #54

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

