### PR TITLE
Fix missing apt-key not found on latest Ubuntu server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 # See License.txt for license information.
-FROM mysql:5.7
+FROM mysql:5.7-debian
 
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 467B942D3A79BD29
 RUN apt-get update && apt-get install -y ca-certificates


### PR DESCRIPTION
#### Summary
Docker hub uses the `Ubuntu: 20.04` which misses `dirmngr`. The package is used for managing and downloading OpenGPG and X.509 certificates.

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-3909
